### PR TITLE
Update to tsdat v0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tsdat >=0.4.0, <0.5.0
+tsdat >=0.5.0, <0.6.0
 cmocean  
 notebook
 act-atmos

--- a/templates/ingest/{{ cookiecutter.module }}/converters.py
+++ b/templates/ingest/{{ cookiecutter.module }}/converters.py
@@ -6,11 +6,11 @@ dataset.yaml definition.
 -------------------------------------------------------------------------------------"""
 
 import xarray as xr
+from typing import Any, Optional
 
-from typing import Any
 from pydantic import BaseModel, Extra
-from tsdat.io.base import DataConverter
-from tsdat.config.dataset import DatasetConfig
+from tsdat import DataConverter, DatasetConfig, RetrievedDataset
+
 
 # DEVELOPER: Implement your custom DataConverter, giving it a better name and
 # documentation as you do so.
@@ -40,11 +40,25 @@ class CustomDataConverter(DataConverter):
 
     def convert(
         self,
-        dataset: xr.Dataset,
-        dataset_config: DatasetConfig,
+        data: xr.DataArray,
         variable_name: str,
+        dataset_config: DatasetConfig,
+        retrieved_dataset: RetrievedDataset,
         **kwargs: Any,
-    ) -> xr.Dataset:
-        # Add your data conversion logic here
+    ) -> Optional[xr.DataArray]:
+        """----------------------------------------------------------------------------
+        Applies a custom conversion to the retrieved data.
+
+        Args:
+            data (xr.DataArray): The DataArray corresponding with the retrieved data
+                variable to convert.
+            variable_name (str): The name of the variable to convert.
+            dataset_config (DatasetConfig): The output dataset configuration.
+            retrieved_dataset (RetrievedDataset): The retrieved dataset structure.
+
+        Returns:
+            Optional[xr.DataArray]: The converted data as an xr.DataArray, or None if
+                the conversion was done in place.
+
+        ----------------------------------------------------------------------------"""
         raise NotImplementedError
-        return dataset

--- a/templates/ingest/{{ cookiecutter.module }}/qc.py
+++ b/templates/ingest/{{ cookiecutter.module }}/qc.py
@@ -35,7 +35,7 @@ class CustomQualityChecker(QualityChecker):
         # True values in the failures array indicate a quality problem.
         var_data = dataset[variable_name]
         failures: NDArray[np.bool8] = np.zeros_like(var_data, dtype=np.bool8)  # type: ignore
-
+        raise NotImplementedError
         return failures
 
 
@@ -68,5 +68,5 @@ class CustomQualityHandler(QualityHandler):
     def run(
         self, dataset: xr.Dataset, variable_name: str, failures: NDArray[np.bool8]
     ) -> xr.Dataset:
-
+        raise NotImplementedError
         return dataset

--- a/templates/ingest/{{ cookiecutter.module }}/readers.py
+++ b/templates/ingest/{{ cookiecutter.module }}/readers.py
@@ -33,4 +33,5 @@ class CustomDataReader(DataReader):
         # DEVELOPER: Implement the read method. This takes an input_key which is the path
         # to the file being run. It should open the file and return either a single
         # Dataset object, or a mapping of strings to Datasets.
+        raise NotImplementedError
         return xr.Dataset()


### PR DESCRIPTION
This PR updates the template to account for breaking changes made in tsdat release v0.5.0; namely the new method signature for `DataConverter.convert()`

Additionally `NotImplementedError` errors are now raised by default in boilerplate QC and DataReader code.