### PR TITLE
Fix cookiecutter netCDF/binary data bug

### DIFF
--- a/templates/ingest/cookiecutter.json
+++ b/templates/ingest/cookiecutter.json
@@ -21,5 +21,9 @@
     ],
     "module": "{{ cookiecutter.ingest_name | slugify(separator='_') }}",
     "classname": "{{ cookiecutter.module | replace('_', ' ') | title | replace(' ', '') }}",
-    "location_id": "{{ cookiecutter.ingest_location | slugify(separator='_') }}"
+    "location_id": "{{ cookiecutter.ingest_location | slugify(separator='_') }}",
+    "_copy_without_render": [
+        "*.nc",
+        "**/*.nc"
+    ]
 }

--- a/templates/vap/cookiecutter.json
+++ b/templates/vap/cookiecutter.json
@@ -12,5 +12,9 @@
     ],
     "module": "vap_{{ cookiecutter.vap_name | slugify(separator='_') }}",
     "classname": "{{ cookiecutter.module | replace('_', ' ') | title | replace(' ', '') }}",
-    "location_id": "{{ cookiecutter.location | slugify(separator='_') }}"
+    "location_id": "{{ cookiecutter.location | slugify(separator='_') }}",
+    "_copy_without_render": [
+        "*.nc",
+        "**/*.nc"
+    ]
 }


### PR DESCRIPTION
In the latest version of the `binaryornot` dependency used by the `cookiecutter` library to detect binary files (v0.6.0) when creating templates, it misclassifies netcdf files as non-binary and tries to generate a template from it (throwing an error) (the `abc.example.a1.20220424.000000.nc` data file in the `tests/data/output` folder for both ingest and vap pipeline templates).

Adding the `_copy_without_render` field to the `cookiecutter.json` files resolves the issue:

```
{
  ...
  "_copy_without_render": [
    "*.nc",
    "**/*.nc"
  ]
}
```

Credit to @Synerge360 and @cromwellPNNL for identifying the issue and suggesting the fix.