### PR TITLE
Update gh actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-13"]
-        python-version: ["3.11"]
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Update macos runner to latest (tests were being skipped due to macos-13 being deprecated)
- Add python 3.12 and 3.13 to the test matrix (was 3.11-only)